### PR TITLE
Provide configured oauthHost via $store.state.oauth.host

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -81,6 +81,7 @@ Handler.prototype.saveData = async function saveData (token) {
   const { accessToken, refreshToken, expires } = token
   this.req[this.opts.sessionName].token = { accessToken, refreshToken, expires }
   this.req.accessToken = accessToken
+  this.req.oauthHost = this.opts.oauthHost
 
   const fetchUser = async () => {
     try {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -13,7 +13,8 @@ const initStore = async context => {
     namespaced: true,
     state: {
       accessToken: (context.req && context.req.accessToken),
-      user: (context.req && context.req.user)
+      user: (context.req && context.req.user),
+      host: (context.req && context.req.oauthHost)
     }
   })
 }

--- a/lib/server-middleware.js
+++ b/lib/server-middleware.js
@@ -14,12 +14,20 @@ module.exports = options => async (req, res, next) => {
   const optionSetter = setCustomValues(options, req)
   await Promise.all(customKeys.map(optionSetter))
 
-  const handler = new Handler({ req, res, next, options })
+  var handler = new Handler({ req, res, next, options })
 
   // Start the OAuth dance
   if (handler.isRoute('login')) {
-    const redirectUrl = parse(req.url.split('?')[1])['redirect-url'] || '/'
-    return handler.redirectToOAuth(redirectUrl)
+    const queryParams = parse(req.url.split('?')[1])
+
+    const redirectUrl = queryParams['redirect-url'] || '/'
+    const oauthHost = queryParams['oauthHost'] || null
+    if(oauthHost && !(oauthHost.toLowerCase() === handler.opts.oauthHost.toLowerCase())) {
+        // re-configure oauthHost
+        options.oauthHost = oauthHost
+        handler = new Handler({ req, res, next, options })
+    }
+    return handler.redirectToOAuth(redirectUrl, oauthHost)
   }
 
   // Complete the OAuth dance


### PR DESCRIPTION
I want to re-use the configured host for subsequent initializations of clients. In my special case, the SwaggerClient. For this i propose to add the connected host to $store.state.oauth.host as done by this patch.