### PR TITLE
Allow OAuth2 to be instantiated with custom request

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -114,9 +114,10 @@ Handler.prototype.updateToken = async function updateToken () {
     newToken.expiresIn(new Date(token.expires))
 
     if (newToken.expired()) {
-      const { accessToken, refreshToken } = await newToken.refresh()
+      const { accessToken, refreshToken, expires } = await newToken.refresh()
       token.accessToken = accessToken
       token.refreshToken = refreshToken
+      token.expires = expires
     }
   } catch (e) {
     errorLog(e)

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -54,7 +54,10 @@ Handler.prototype.createSession = function createSession () {
   const session = sessions({
     cookieName: this.opts.sessionName,
     secret: this.opts.secretKey,
-    duration: 24 * 60 * 60 * 1000
+    duration: 24 * 60 * 60 * 1000,
+    cookie: this.opts.domain ? {
+      domain: this.opts.domain
+    } : undefined
   })
   return new Promise(resolve => session(this.req, this.res, resolve))
 }

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -36,7 +36,7 @@ Handler.prototype.createAuth = function createAuth () {
     clientSecret,
     redirectUri: `${protocol}://${this.req.headers.host}/auth/callback`,
     scopes
-  })
+  }, this.opts.request)
 }
 
 Handler.prototype.redirect = function redirect (path) {

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -27,14 +27,19 @@ Handler.prototype.createAuth = function createAuth () {
     oauthClientSecret: clientSecret,
     scopes = []
   } = this.opts
-  const protocol = this.req.headers['x-forwarded-proto'] || this.req.headers['X-Forwarded-Proto'] || 'http'
+  let baseUrl = process.env.BASE_URL;
+
+  if (!baseUrl) {
+    const protocol = this.req.headers['x-forwarded-proto'] || this.req.headers['X-Forwarded-Proto'] || 'http'
+    baseUrl = `${protocol}://${this.req.headers.host}`;
+  }
 
   return new OAuth2({
     authorizationUri: join(oauthHost, authorizationPath),
     accessTokenUri: join(oauthHost, accessTokenPath),
     clientId,
     clientSecret,
-    redirectUri: `${protocol}://${this.req.headers.host}/auth/callback`,
+    redirectUri: `${baseUrl}/auth/callback`,
     scopes
   }, this.opts.request)
 }


### PR DESCRIPTION
This PR fixes #28. It adds an option to pass custom request handler in nuxt.config.js, which could be something like this:

```js
require("dotenv").config();
const popsicle = require("popsicle");

// ...

module.exports = {
  // ...
  oauth: {
    // ...
    request: (method, url, body, headers) => {
      return popsicle
        .get({
          url: url,
          body: body,
          method: method,
          headers: headers,
          transport: popsicle.createTransport({
            // reject self-signed certificates only on production environment
            rejectUnauthorized:
              process.env.ALLOW_INSECURE_OAUTH_ENDPOINT === "0"
          })
        })
        .then(function(res) {
          return {
            status: res.status,
            body: res.body
          };
        });
    }
  },
};
```