### PR TITLE
Updated redirect param to encode the resulting URL

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -31,14 +31,14 @@ middleware.auth = context => {
   const { accessToken = null } = context.store.state[moduleName]
 
   if (!isAuthenticated || !!accessToken) return
-  context.redirect(302, '/auth/login?redirect-url=' + context.route.fullPath)
+  context.redirect(302, '/auth/login?redirect-url=' + encodeURIComponent(context.route.fullPath))
 }
 
 export default async (context, inject) => {
   await initStore(context)
 
   const createAuth = action => (redirectUrl = context.route.fullPath) =>
-    context.redirect('/auth/' + action + '?redirect-url=' + redirectUrl)
+    context.redirect('/auth/' + action + '?redirect-url=' + encodeURIComponent(redirectUrl))
 
   inject('login', createAuth('login'))
   inject('logout', createAuth('logout'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-oauth",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "OAuth module for your Nuxt applications",
   "main": "index.js",
   "repository": "https://github.com/SohoHouse/nuxt-oauth",

--- a/test/unit/plugin.js
+++ b/test/unit/plugin.js
@@ -170,7 +170,7 @@ describe('Helpers', () => {
         const redirectUrl = '/custom'
         action(redirectUrl)
 
-        const expected = `/auth/${actionName}?redirect-url=${redirectUrl}`
+        const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(redirectUrl)}`
         expect(context.redirect).toHaveBeenCalledWith(expected)
       })
 
@@ -178,7 +178,7 @@ describe('Helpers', () => {
         const redirectUrl = '/custom?foo=bar'
         action(redirectUrl)
 
-        const expected = `/auth/${actionName}?redirect-url=${redirectUrl}`
+        const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(redirectUrl)}`
         expect(context.redirect).toHaveBeenCalledWith(expected)
       })
     })


### PR DESCRIPTION
- URIs were not encoded
- Resulted in invalid URLs with query params
- Code was splitting at `?`, so query params were not being sent over correctly