### PR TITLE
feat: allow bearer for pass-through authorization

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -39,6 +39,11 @@ Handler.prototype.createAuth = function createAuth () {
   })
 }
 
+/**
+ * TODO Handle some max retry logic to stop the spam when a token is not valid
+ * * x-Retries - could be passed as a simple header to and from the identity server
+ * * npm library (requestretry)[https://www.npmjs.com/package/requestretry] might also be helpful
+ */
 Handler.prototype.redirect = function redirect (path) {
   this.res.writeHead(302, { location: path })
   this.res.end()

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -59,6 +59,22 @@ Handler.prototype.createSession = function createSession () {
   return new Promise(resolve => session(this.req, this.res, resolve))
 }
 
+Handler.prototype.checkRequestAuthorization = async function checkRequestAuthorization () {
+  const existingToken = this.extractToken()
+
+  try {
+    // when an existing token exists try to authenticate the session
+    if (existingToken) {
+      await this.saveData({ accessToken: existingToken })
+    }
+  } catch (e) {
+    // saveData failed, clear the session
+    return this.logout()
+  }
+
+  return false
+}
+
 Handler.prototype.authenticateCallbackToken = async function authenticateCallbackToken () {
   let redirectUrl
   try {
@@ -158,6 +174,17 @@ Handler.prototype.isRoute = function isRoute (route) {
   const path = this.constructor.routes[route]
 
   return this.req.url.startsWith(path)
+}
+
+Handler.prototype.extractToken = function extractToken () {
+  const { headers: { authorization } } = this.req
+
+  if (!authorization) return null
+
+  // Take the second split, handles all token types
+  const [, token] = authorization.split(' ')
+
+  return token
 }
 
 module.exports = Handler

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -41,7 +41,7 @@ Handler.prototype.createAuth = function createAuth () {
 
 /**
  * TODO Handle some max retry logic to stop the spam when a token is not valid
- * * x-Retries - could be passed as a simple header to and from the identity server
+ * * x-Retries - could be passed as a simple header
  * * npm library (requestretry)[https://www.npmjs.com/package/requestretry] might also be helpful
  */
 Handler.prototype.redirect = function redirect (path) {

--- a/lib/server-middleware.js
+++ b/lib/server-middleware.js
@@ -7,6 +7,20 @@ const setCustomValues = (options, req) => async key => {
   options[key] = await options[key](req)
 }
 
+const extractToken = req => {
+  const { headers: { authorization } } = req
+
+  if (!authorization) return null
+
+  // Take the second split, handles all token types
+  const [, token] = authorization.split(' ')
+
+  return token
+}
+
+const isEmptyObject = (subject = {}) =>
+  Object.entries(subject).length === 0 && subject.constructor === Object
+
 module.exports = options => async (req, res, next) => {
   if (options.testMode) createTestHandler(Handler)
 
@@ -16,6 +30,22 @@ module.exports = options => async (req, res, next) => {
 
   const handler = new Handler({ req, res, next, options })
 
+  const existingToken = extractToken(req)
+  let invalidToken = false
+
+  // when an existing token exists try to authenticate the session
+  if (existingToken) {
+    await handler.saveData({ accessToken: existingToken })
+
+    // If we have a user, the token was valid
+    if (!isEmptyObject(req.user)) {
+      return next()
+    }
+
+    // Detected an invalid token being used, we should clear the session
+    invalidToken = true
+  }
+
   // Start the OAuth dance
   if (handler.isRoute('login')) {
     const redirectUrl = parse(req.url.split('?')[1])['redirect-url'] || '/'
@@ -23,12 +53,17 @@ module.exports = options => async (req, res, next) => {
   }
 
   // Complete the OAuth dance
-  if (handler.isRoute('callback')) return handler.authenticateCallbackToken()
+  if (handler.isRoute('callback')) {
+    return handler.authenticateCallbackToken()
+  }
 
   // Clear the session
-  if (handler.isRoute('logout')) return handler.logout()
+  if (invalidToken || handler.isRoute('logout')) {
+    return handler.logout()
+  }
 
   // On any other route, refresh the token
   await handler.updateToken()
+
   return next()
 }

--- a/lib/server-middleware.js
+++ b/lib/server-middleware.js
@@ -7,20 +7,6 @@ const setCustomValues = (options, req) => async key => {
   options[key] = await options[key](req)
 }
 
-const extractToken = req => {
-  const { headers: { authorization } } = req
-
-  if (!authorization) return null
-
-  // Take the second split, handles all token types
-  const [, token] = authorization.split(' ')
-
-  return token
-}
-
-const isEmptyObject = (subject = {}) =>
-  Object.entries(subject).length === 0 && subject.constructor === Object
-
 module.exports = options => async (req, res, next) => {
   if (options.testMode) createTestHandler(Handler)
 
@@ -29,22 +15,6 @@ module.exports = options => async (req, res, next) => {
   await Promise.all(customKeys.map(optionSetter))
 
   const handler = new Handler({ req, res, next, options })
-
-  const existingToken = extractToken(req)
-  let invalidToken = false
-
-  // when an existing token exists try to authenticate the session
-  if (existingToken) {
-    await handler.saveData({ accessToken: existingToken })
-
-    // If we have a user, the token was valid
-    if (!isEmptyObject(req.user)) {
-      return next()
-    }
-
-    // Detected an invalid token being used, we should clear the session
-    invalidToken = true
-  }
 
   // Start the OAuth dance
   if (handler.isRoute('login')) {
@@ -58,9 +28,12 @@ module.exports = options => async (req, res, next) => {
   }
 
   // Clear the session
-  if (invalidToken || handler.isRoute('logout')) {
+  if (handler.isRoute('logout')) {
     return handler.logout()
   }
+
+  // Check to see if the request has a valid bearer token
+  await handler.checkRequestAuthorization()
 
   // On any other route, refresh the token
   await handler.updateToken()

--- a/test/unit/server-middleware.js
+++ b/test/unit/server-middleware.js
@@ -66,6 +66,11 @@ describe('Server Middleware', () => {
   })
 
   describe('for a normal route', () => {
+    it('checks the request for a token', async () => {
+      await middleware(req, res, next)
+      expect(Handler.prototype.checkRequestAuthorization).toHaveBeenCalled()
+    })
+
     it('updates the token', async () => {
       await middleware(req, res, next)
       expect(Handler.prototype.updateToken).toHaveBeenCalled()


### PR DESCRIPTION
## Summary

Allow an `authorization` header to be passed into our applications.

This should enable web views from mobile to load the application without passing through the identity server.

## Tickets
[Allow authentication using Authorization header as well as a session](https://sohohousedev.atlassian.net/browse/MWEB-283)