### PR TITLE
Refresh token

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,5 @@
+const INVALID_SESSION = 'Invalid session'
+
+module.exports = {
+  INVALID_SESSION
+}

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -135,8 +135,10 @@ Handler.prototype.updateToken = async function updateToken () {
     errorLog(e)
     token = null
   }
-  this.saveData(token)
-  return true
+
+  await this.saveData(token)
+
+  return token
 }
 
 Handler.prototype.redirectToOAuth = async function redirectToOAuth (redirect) {
@@ -167,7 +169,8 @@ Handler.prototype.logout = async function logout () {
 Handler.routes = {
   login: '/auth/login',
   callback: '/auth/callback',
-  logout: '/auth/logout'
+  logout: '/auth/logout',
+  refresh: '/auth/refresh'
 }
 
 Handler.prototype.isRoute = function isRoute (route) {

--- a/lib/server-middleware.js
+++ b/lib/server-middleware.js
@@ -1,6 +1,8 @@
 const { parse } = require('qs')
+
 const Handler = require('./handler')
 const createTestHandler = require('./test-mode')
+const { INVALID_SESSION } = require('./constants')
 
 const setCustomValues = (options, req) => async key => {
   if (typeof options[key] !== 'function') return
@@ -15,6 +17,22 @@ module.exports = options => async (req, res, next) => {
   await Promise.all(customKeys.map(optionSetter))
 
   const handler = new Handler({ req, res, next, options })
+
+  // Refresh the token with the OAuth provider
+  // useful for client side 401 handling
+  if (handler.isRoute('refresh')) {
+    const { accessToken } = await handler.updateToken() || {}
+    const isAuthenticated = !!accessToken
+    res.writeHead(isAuthenticated ? 200 : 401, { 'Content-Type': 'application/json' })
+
+    if (isAuthenticated) {
+      const body = JSON.stringify({ accessToken })
+      return res.end(body)
+    }
+
+    const body = JSON.stringify({ error: INVALID_SESSION })
+    return res.end(body)
+  }
 
   // Start the OAuth dance
   if (handler.isRoute('login')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-oauth",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "OAuth module for your Nuxt applications",
   "main": "index.js",
   "repository": "https://github.com/SohoHouse/nuxt-oauth",

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -5,6 +5,7 @@ const { Nuxt, Builder } = require('nuxt')
 const request = require('request-promise-native')
 
 const config = require('./fixture/nuxt.config')
+const { INVALID_SESSION } = require('../../lib/constants')
 
 const url = path => `http://localhost:${process.env.PORT}${path}`
 const get = path => request({
@@ -49,6 +50,15 @@ describe('without test mode', () => {
     const { statusCode, headers } = await get('/auth/login')
     expect(statusCode).toEqual(302)
     expect(headers.location).toContain(config.oauth.oauthHost())
+  })
+
+  test('invalid session refresh token', async () => {
+    const { statusCode, body } = await get('/auth/refresh')
+
+    const parsedBody = JSON.parse(body)
+
+    expect(statusCode).toEqual(401)
+    expect(parsedBody.error).toBe(INVALID_SESSION)
   })
 })
 

--- a/test/unit/handler.js
+++ b/test/unit/handler.js
@@ -244,6 +244,11 @@ describe('Handler', () => {
       expect(handler.createSession).toHaveBeenCalled()
     })
 
+    it('returns the token', async () => {
+      const returnedToken = await handler.updateToken()
+      expect(returnedToken).toEqual(token)
+    })
+
     it('does nothing else if no token exists already', async () => {
       handler.req[options.sessionName] = {}
       await handler.updateToken()

--- a/test/unit/server-middleware.js
+++ b/test/unit/server-middleware.js
@@ -1,7 +1,7 @@
 import Middleware from '@/server-middleware'
 import Handler from '@/handler'
 
-import { INVALID_SESSION } from './constants'
+import { INVALID_SESSION } from '../../lib/constants'
 
 jest.mock('@/handler.js', () => jest.genMockFromModule('../../lib/handler'))
 

--- a/test/unit/server-middleware.js
+++ b/test/unit/server-middleware.js
@@ -1,6 +1,8 @@
 import Middleware from '@/server-middleware'
 import Handler from '@/handler'
 
+import { INVALID_SESSION } from './constants'
+
 jest.mock('@/handler.js', () => jest.genMockFromModule('../../lib/handler'))
 
 Handler.prototype.redirectToOAuth = jest.fn()
@@ -18,7 +20,10 @@ beforeEach(() => {
     headers: { host: 'localhost:3000' },
     url: '/path'
   }
-  res = {}
+  res = {
+    end: jest.fn(),
+    writeHead: jest.fn()
+  }
   options = {
     oauthHost: 'oauthHost',
     oauthClientID: 'oauthClientID',
@@ -119,6 +124,40 @@ describe('Server Middleware', () => {
     it('complets the oauth handshake', async () => {
       await middleware(req, res, next)
       expect(Handler.prototype.authenticateCallbackToken).toHaveBeenCalled()
+    })
+  })
+
+  describe('for /auth/refresh', () => {
+    beforeEach(() => {
+      req.url = '/auth/refresh'
+      Handler.prototype.isRoute = jest.fn(route => route === 'refresh')
+    })
+
+    it('does not call next', async () => {
+      await middleware(req, res, next)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('refreshes the token', async () => {
+      const accessToken = 'validToken'
+
+      Handler.prototype.updateToken.mockReturnValueOnce({ accessToken })
+
+      await middleware(req, res, next)
+
+      expect(Handler.prototype.updateToken).toHaveBeenCalled()
+      expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' })
+      expect(res.end).toHaveBeenCalledWith(JSON.stringify({ accessToken }))
+    })
+
+    it('returns 401 on invalid session', async () => {
+      Handler.prototype.updateToken.mockReturnValueOnce(null)
+
+      await middleware(req, res, next)
+
+      expect(Handler.prototype.updateToken).toHaveBeenCalled()
+      expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' })
+      expect(res.end).toHaveBeenCalledWith(JSON.stringify({ error: INVALID_SESSION }))
     })
   })
 })


### PR DESCRIPTION
## Refresh token

Hooks into the `server-middleware` with the ability to refresh tokens via an endpoint `/auth/refresh`.

- Returns 401 when invalid refresh token is in session.
- Returns new token when valid refresh token is in session