### PR TITLE
Fix route component

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,11 +36,11 @@ module.exports = function NuxtOAuth (moduleOptions) {
     routes.push({
       name: 'oauth-login',
       path: '/auth/login',
-      pageComponent: res(options.pageComponentPath)
+      component: res(options.pageComponentPath)
     }, {
       name: 'oauth-logout',
       path: '/auth/logout',
-      pageComponent: res(options.pageComponentPath)
+      component: res(options.pageComponentPath)
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-oauth",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "OAuth module for your Nuxt applications",
   "main": "index.js",
   "repository": "https://github.com/SohoHouse/nuxt-oauth",


### PR DESCRIPTION
# Bug - Renaming route component

The name for a component in the route was changed to an incorrect value `pageComponent`.

Rectify the mistake, `pageComponent` -> `component`.