### PR TITLE
fix: client route wants to hard reload page

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -18,27 +18,35 @@ const initStore = async context => {
   })
 }
 
-const isAuthenticatedRoute = component =>
-  typeof component.options.authenticated === 'function' ? component.options.authenticated(component) : component.options.authenticated
+const isAuthenticatedRoute = component => typeof component.options.authenticated === 'function' ? component.options.authenticated(component) : component.options.authenticated
 
 const checkAuthenticatedRoute = ({ route: { matched } }) => process.client
   ? matched.some(({ components }) => Object.values(components).some(c => isAuthenticatedRoute(c)))
-  : matched.some(({ components }) => Object.values(components).some(({ _Ctor }) =>
-    Object.values(_Ctor).some(c => c.options && isAuthenticatedRoute(c))))
+  : matched.some(({ components }) => components && Object.values(components).some(({ _Ctor }) => _Ctor && Object.values(_Ctor).some(c => c && c.options && isAuthenticatedRoute(c))))
+
+const redirectToOAuth = ({ redirect }, action, redirectUrl = '') => {
+  const encodedRedirectUrl = `/auth/${action}?redirect-url=${encodeURIComponent(redirectUrl)}`
+
+  if (process.client) {
+    window.location.assign(encodedRedirectUrl)
+  } else {
+    redirect(302, encodedRedirectUrl)
+  }
+}
 
 middleware.auth = context => {
   const isAuthenticated = checkAuthenticatedRoute(context)
   const { accessToken = null } = context.store.state[moduleName]
 
   if (!isAuthenticated || !!accessToken) return
-  context.redirect(302, '/auth/login?redirect-url=' + encodeURIComponent(context.route.fullPath))
+  redirectToOAuth(context, 'login', context.route.fullPath)
 }
 
 export default async (context, inject) => {
   await initStore(context)
 
   const createAuth = action => (redirectUrl = context.route.fullPath) =>
-    context.redirect('/auth/' + action + '?redirect-url=' + encodeURIComponent(redirectUrl))
+    redirectToOAuth(context, action, redirectUrl)
 
   inject('login', createAuth('login'))
   inject('logout', createAuth('logout'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-oauth",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "OAuth module for your Nuxt applications",
   "main": "index.js",
   "repository": "https://github.com/SohoHouse/nuxt-oauth",

--- a/test/unit/plugin.js
+++ b/test/unit/plugin.js
@@ -8,6 +8,11 @@ let context
 
 beforeEach(() => {
   process.client = true
+  global.window = {
+    location: {
+      assign: jest.fn()
+    }
+  }
   context = {
     store: {
       registerModule: jest.fn(),
@@ -18,7 +23,8 @@ beforeEach(() => {
     redirect: jest.fn(),
     route: {
       matched: [],
-      path: '/path'
+      path: '/path',
+      fullPath: '/path?with=query'
     }
   }
 })
@@ -48,7 +54,7 @@ describe('Middleware', () => {
     it('redirects', async () => {
       await (Middleware.auth(context))
 
-      expect(context.redirect).not.toHaveBeenCalled()
+      expect(global.window.location.assign).not.toHaveBeenCalled()
     })
   })
 
@@ -61,7 +67,7 @@ describe('Middleware', () => {
     it('redirects', async () => {
       await (Middleware.auth(context))
 
-      expect(context.redirect).toHaveBeenCalled()
+      expect(global.window.location.assign).toHaveBeenCalled()
     })
 
     describe('with an access token', () => {
@@ -72,7 +78,7 @@ describe('Middleware', () => {
       it('does nothing', async () => {
         await (Middleware.auth(context))
 
-        expect(context.redirect).not.toHaveBeenCalled()
+        expect(global.window.location.assign).not.toHaveBeenCalled()
       })
     })
   })
@@ -90,7 +96,7 @@ describe('Middleware', () => {
       it('redirects', async () => {
         await (Middleware.auth(context))
 
-        expect(context.redirect).toHaveBeenCalled()
+        expect(global.window.location.assign).toHaveBeenCalled()
       })
 
       it('calls authenticated', async () => {
@@ -110,7 +116,7 @@ describe('Middleware', () => {
         it('does nothing', async () => {
           await (Middleware.auth(context))
 
-          expect(context.redirect).not.toHaveBeenCalled()
+          expect(global.window.location.assign).not.toHaveBeenCalled()
         })
       })
     })
@@ -130,7 +136,7 @@ describe('Middleware', () => {
         expect(unAuthenticatedMock).toHaveBeenCalledWith({
           options: { authenticated: unAuthenticatedMock }
         })
-        expect(context.redirect).not.toHaveBeenCalled()
+        expect(global.window.location.assign).not.toHaveBeenCalled()
       })
     })
   })
@@ -162,8 +168,8 @@ describe('Helpers', () => {
       it('redirects correctly', () => {
         action()
 
-        const expected = `/auth/${actionName}?redirect-url=${context.route.fullPath}`
-        expect(context.redirect).toHaveBeenCalledWith(expected)
+        const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(context.route.fullPath)}`
+        expect(global.window.location.assign).toHaveBeenCalledWith(expected)
       })
 
       it('redirects correctly with custom redirect url', () => {
@@ -171,7 +177,7 @@ describe('Helpers', () => {
         action(redirectUrl)
 
         const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(redirectUrl)}`
-        expect(context.redirect).toHaveBeenCalledWith(expected)
+        expect(global.window.location.assign).toHaveBeenCalledWith(expected)
       })
 
       it('retains query parameters during redirect', () => {
@@ -179,7 +185,7 @@ describe('Helpers', () => {
         action(redirectUrl)
 
         const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(redirectUrl)}`
-        expect(context.redirect).toHaveBeenCalledWith(expected)
+        expect(global.window.location.assign).toHaveBeenCalledWith(expected)
       })
     })
   )


### PR DESCRIPTION
# Client routing

Currently the client routing will use nuxt `context.redirect`. This will internally use the client router to switch routes before moving to serve-middleware, therefore casing a flash in layout with potential visible renderings for users.

Now, we use `location.assign` to redirect users directly to the node process handling requests to the OAuth service.