### PR TITLE
Token refresh

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -8,7 +8,9 @@ function Handler (opts) {
   this.init(opts)
 }
 
-Handler.prototype.init = function init ({ req, res, next, options = { sessionName: 'nuxtSession' } } = {}) {
+Handler.prototype.init = function init ({
+  req, res, next, options = { sessionName: 'nuxtSession' }
+} = {}) {
   this.req = req
   this.res = res
   this.next = next
@@ -57,6 +59,12 @@ Handler.prototype.createSession = function createSession () {
     duration: 24 * 60 * 60 * 1000
   })
   return new Promise(resolve => session(this.req, this.res, resolve))
+}
+
+Handler.prototype.getSessionToken = function getSessionToken () {
+  const { token } = this.req[this.opts.sessionName] || {}
+
+  return token || {}
 }
 
 Handler.prototype.checkRequestAuthorization = async function checkRequestAuthorization () {
@@ -117,28 +125,58 @@ Handler.prototype.saveData = async function saveData (token) {
   return true
 }
 
-Handler.prototype.updateToken = async function updateToken () {
+Handler.prototype.authenticate = async function authenticate () {
   await this.createSession()
-  let { token } = this.req[this.opts.sessionName]
-  if (!token) return false
 
-  try {
-    const newToken = await this.auth.createToken(token.accessToken, token.refreshToken, 'bearer')
-    newToken.expiresIn(new Date(token.expires))
+  const { accessToken, refreshToken } = this.getSessionToken()
 
-    if (newToken.expired()) {
-      const { accessToken, refreshToken } = await newToken.refresh()
-      token.accessToken = accessToken
-      token.refreshToken = refreshToken
-    }
-  } catch (e) {
-    errorLog(e)
-    token = null
+  if (!accessToken) {
+    return null
   }
 
-  await this.saveData(token)
+  try {
+    const token = await this.auth.createToken(accessToken, refreshToken, 'bearer')
 
-  return token
+    token.expiresIn(new Date(token.expires))
+
+    if (token.expired()) {
+      const refreshedToken = await token.refresh()
+
+      await this.saveData(refreshedToken)
+
+      return refreshedToken
+    }
+
+    await this.saveData(token)
+
+    return token
+  } catch (e) {
+    errorLog(e)
+    return null
+  }
+}
+
+Handler.prototype.useRefreshToken = async function useRefreshToken () {
+  await this.createSession()
+
+  const { accessToken, refreshToken } = this.getSessionToken()
+
+  if (!accessToken) {
+    return null
+  }
+
+  try {
+    const token = await this.auth.createToken(accessToken, refreshToken, 'bearer')
+
+    const refreshedToken = await token.refresh()
+
+    await this.saveData(refreshedToken)
+
+    return refreshedToken
+  } catch (e) {
+    errorLog(e)
+    return null
+  }
 }
 
 Handler.prototype.redirectToOAuth = async function redirectToOAuth (redirect) {

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -136,7 +136,7 @@ Handler.prototype.authenticate = async function authenticate () {
 
   const { accessToken, refreshToken } = this.getSessionToken()
 
-  if (!accessToken) {
+  if (!accessToken || !refreshToken) {
     return null
   }
 
@@ -167,7 +167,7 @@ Handler.prototype.useRefreshToken = async function useRefreshToken () {
 
   const { accessToken, refreshToken } = this.getSessionToken()
 
-  if (!accessToken) {
+  if (!accessToken || !refreshToken) {
     return null
   }
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -125,6 +125,12 @@ Handler.prototype.saveData = async function saveData (token) {
   return true
 }
 
+// @deprecated updateToken renamed to authenticate
+Handler.prototype.updateToken = function updateToken (...args) {
+  errorLog('nuxt-oauth [DEPRECATED] - please change any reference from `updateToken` to `authenticate`')
+  return this.authenticate(...args)
+}
+
 Handler.prototype.authenticate = async function authenticate () {
   await this.createSession()
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,18 +4,26 @@ import middleware from '@@/.nuxt/middleware'
 const moduleName = '<%= options.moduleName %>'
 
 const initStore = async context => {
-  if (process.client) return
   if (!context.store) {
-    throw new Error('nuxt-oauth requires a Vuex store!')
+    context.error('nuxt-oauth requires a Vuex store!')
+    return
   }
 
-  context.store.registerModule(moduleName, {
-    namespaced: true,
-    state: {
-      accessToken: (context.req && context.req.accessToken),
-      user: (context.req && context.req.user)
+  context.store.registerModule(
+    moduleName,
+    {
+      namespaced: true,
+      state: {
+        accessToken: (context.req && context.req.accessToken),
+        user: (context.req && context.req.user)
+      },
+      mutations: {
+        setAccessToken (state, accessToken) {
+          state.accessToken = accessToken
+        }
+      }
     }
-  })
+  )
 }
 
 const isAuthenticatedRoute = component => typeof component.options.authenticated === 'function' ? component.options.authenticated(component) : component.options.authenticated
@@ -45,8 +53,7 @@ middleware.auth = context => {
 export default async (context, inject) => {
   await initStore(context)
 
-  const createAuth = action => (redirectUrl = context.route.fullPath) =>
-    redirectToOAuth(context, action, redirectUrl)
+  const createAuth = action => (redirectUrl = context.route.fullPath) => redirectToOAuth(context, action, redirectUrl)
 
   inject('login', createAuth('login'))
   inject('logout', createAuth('logout'))

--- a/lib/server-middleware.js
+++ b/lib/server-middleware.js
@@ -16,20 +16,22 @@ module.exports = options => async (req, res, next) => {
   const optionSetter = setCustomValues(options, req)
   await Promise.all(customKeys.map(optionSetter))
 
-  const handler = new Handler({ req, res, next, options })
+  const handler = new Handler({
+    req, res, next, options
+  })
 
   // Refresh the token with the OAuth provider
   // useful for client side 401 handling
   if (handler.isRoute('refresh')) {
-    const { accessToken } = await handler.updateToken() || {}
-    const isAuthenticated = !!accessToken
-    res.writeHead(isAuthenticated ? 200 : 401, { 'Content-Type': 'application/json' })
+    const token = await handler.useRefreshToken()
 
-    if (isAuthenticated) {
-      const body = JSON.stringify({ accessToken })
+    if (token) {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      const body = JSON.stringify(token)
       return res.end(body)
     }
 
+    res.writeHead(401, { 'Content-Type': 'application/json' })
     const body = JSON.stringify({ error: INVALID_SESSION })
     return res.end(body)
   }
@@ -53,8 +55,8 @@ module.exports = options => async (req, res, next) => {
   // Check to see if the request has a valid bearer token
   await handler.checkRequestAuthorization()
 
-  // On any other route, refresh the token
-  await handler.updateToken()
+  // On any other route, authenticate
+  await handler.authenticate()
 
   return next()
 }

--- a/lib/server-middleware.js
+++ b/lib/server-middleware.js
@@ -26,8 +26,9 @@ module.exports = options => async (req, res, next) => {
     const token = await handler.useRefreshToken()
 
     if (token) {
+      const { accessToken, expires } = token
       res.writeHead(200, { 'Content-Type': 'application/json' })
-      const body = JSON.stringify(token)
+      const body = JSON.stringify({ accessToken, expires })
       return res.end(body)
     }
 

--- a/lib/test-mode.js
+++ b/lib/test-mode.js
@@ -8,7 +8,7 @@ async function redirectToOAuth () {
   this.next()
 }
 
-async function updateToken () {
+async function authenticate () {
   const fakeToken = await this.createFakeToken()
   this.saveData(fakeToken)
   return true
@@ -17,5 +17,8 @@ async function updateToken () {
 module.exports = Handler => {
   Handler.prototype.createFakeToken = createFakeToken
   Handler.prototype.redirectToOAuth = redirectToOAuth
-  Handler.prototype.updateToken = updateToken
+  Handler.prototype.authenticate = authenticate
+
+  // @deprecated updateToken renamed to authenticate
+  Handler.prototype.updateToken = authenticate
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-oauth",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "OAuth module for your Nuxt applications",
   "main": "index.js",
   "repository": "https://github.com/SohoHouse/nuxt-oauth",

--- a/test/unit/handler.js
+++ b/test/unit/handler.js
@@ -151,6 +151,22 @@ describe('Handler', () => {
     })
   })
 
+  describe('#getSessionToken', () => {
+    it('extracts token from the session', async () => {
+      const handler = new Handler({ req: reqWithSession, res, options })
+      const sessionToken = await handler.getSessionToken()
+
+      expect(sessionToken).toEqual(token)
+    })
+
+    it('returns an empty object when no session exists', async () => {
+      const handler = new Handler({ req, res, options })
+      const sessionToken = await handler.getSessionToken()
+
+      expect(sessionToken).toEqual({})
+    })
+  })
+
   describe('#saveData', () => {
     let handler
     let testToken
@@ -228,47 +244,90 @@ describe('Handler', () => {
     })
   })
 
-  describe('#updateToken', () => {
+  describe('#authenticate', () => {
     let handler
 
     beforeEach(() => {
       handler = new Handler({ req: reqWithSession, res, options })
-      handler.createSession = jest.fn(async () => {})
-      handler.saveData = jest.fn(async () => {})
-
-      handler.auth.createToken = jest.fn(() => mockToken)
+      handler.createSession = jest.fn().mockResolvedValue(null)
+      handler.saveData = jest.fn().mockResolvedValue(null)
+      handler.getSessionToken = jest.fn().mockReturnValue(token)
+      handler.auth.createToken = jest.fn().mockResolvedValue(mockToken)
     })
 
     it('creates a session', async () => {
-      await handler.updateToken()
+      await handler.authenticate()
       expect(handler.createSession).toHaveBeenCalled()
     })
 
     it('returns the token', async () => {
-      const returnedToken = await handler.updateToken()
-      expect(returnedToken).toEqual(token)
+      const returnedToken = await handler.authenticate()
+      expect(returnedToken).toEqual(mockToken)
     })
 
     it('does nothing else if no token exists already', async () => {
       handler.req[options.sessionName] = {}
-      await handler.updateToken()
+      handler.getSessionToken.mockReturnValueOnce({})
 
-      await handler.updateToken()
+      const sessionToken = await handler.authenticate()
+
       expect(mockToken.refresh).not.toHaveBeenCalled()
       expect(handler.saveData).not.toHaveBeenCalled()
+      expect(sessionToken).toBeNull()
     })
 
     it('saves the token', async () => {
-      await handler.updateToken()
+      await handler.authenticate()
       expect(mockToken.refresh).not.toHaveBeenCalled()
-      expect(handler.saveData).toHaveBeenCalledWith(token)
+      expect(handler.auth.createToken).toHaveBeenCalledWith(token.accessToken, token.refreshToken, 'bearer')
+      expect(handler.saveData).toHaveBeenCalledWith(mockToken)
     })
 
     it('refreshes the token if its expired', async () => {
       mockToken.expired.mockImplementationOnce(() => true)
-      await handler.updateToken()
+      await handler.authenticate()
       expect(mockToken.refresh).toHaveBeenCalled()
       expect(handler.saveData).toHaveBeenCalledWith(refreshedToken)
+    })
+  })
+
+  describe('#useRefreshToken', () => {
+    let handler
+
+    beforeEach(() => {
+      handler = new Handler({ req: reqWithSession, res, options })
+      handler.createSession = jest.fn().mockResolvedValue(null)
+      handler.saveData = jest.fn().mockResolvedValue(null)
+      handler.getSessionToken = jest.fn().mockReturnValue(token)
+      handler.auth.createToken = jest.fn().mockResolvedValue(mockToken)
+    })
+
+    it('creates a session', async () => {
+      await handler.useRefreshToken()
+      expect(handler.createSession).toHaveBeenCalled()
+    })
+
+    it('saves the refreshed token', async () => {
+      await handler.useRefreshToken()
+      expect(mockToken.refresh).toHaveBeenCalled()
+      expect(handler.auth.createToken).toHaveBeenCalledWith(token.accessToken, token.refreshToken, 'bearer')
+      expect(handler.saveData).toHaveBeenCalledWith(refreshedToken)
+    })
+
+    it('returns the refreshed token', async () => {
+      const returnedToken = await handler.useRefreshToken()
+      expect(returnedToken).toEqual(refreshedToken)
+    })
+
+    it('does nothing else if no token exists already', async () => {
+      handler.req[options.sessionName] = {}
+      handler.getSessionToken.mockReturnValueOnce({})
+
+      const sessionToken = await handler.useRefreshToken()
+
+      expect(mockToken.refresh).not.toHaveBeenCalled()
+      expect(handler.saveData).not.toHaveBeenCalled()
+      expect(sessionToken).toBeNull()
     })
   })
 

--- a/test/unit/handler.js
+++ b/test/unit/handler.js
@@ -244,6 +244,54 @@ describe('Handler', () => {
     })
   })
 
+  // TODO - this function name was deprecated, but let's be kind and make sure it still works
+  describe('#updateToken', () => {
+    let handler
+
+    beforeEach(() => {
+      handler = new Handler({ req: reqWithSession, res, options })
+      handler.createSession = jest.fn().mockResolvedValue(null)
+      handler.saveData = jest.fn().mockResolvedValue(null)
+      handler.getSessionToken = jest.fn().mockReturnValue(token)
+      handler.auth.createToken = jest.fn().mockResolvedValue(mockToken)
+    })
+
+    it('creates a session', async () => {
+      await handler.updateToken()
+      expect(handler.createSession).toHaveBeenCalled()
+    })
+
+    it('returns the token', async () => {
+      const returnedToken = await handler.updateToken()
+      expect(returnedToken).toEqual(mockToken)
+    })
+
+    it('does nothing else if no token exists already', async () => {
+      handler.req[options.sessionName] = {}
+      handler.getSessionToken.mockReturnValueOnce({})
+
+      const sessionToken = await handler.updateToken()
+
+      expect(mockToken.refresh).not.toHaveBeenCalled()
+      expect(handler.saveData).not.toHaveBeenCalled()
+      expect(sessionToken).toBeNull()
+    })
+
+    it('saves the token', async () => {
+      await handler.updateToken()
+      expect(mockToken.refresh).not.toHaveBeenCalled()
+      expect(handler.auth.createToken).toHaveBeenCalledWith(token.accessToken, token.refreshToken, 'bearer')
+      expect(handler.saveData).toHaveBeenCalledWith(mockToken)
+    })
+
+    it('refreshes the token if its expired', async () => {
+      mockToken.expired.mockImplementationOnce(() => true)
+      await handler.updateToken()
+      expect(mockToken.refresh).toHaveBeenCalled()
+      expect(handler.saveData).toHaveBeenCalledWith(refreshedToken)
+    })
+  })
+
   describe('#authenticate', () => {
     let handler
 

--- a/test/unit/plugin.js
+++ b/test/unit/plugin.js
@@ -37,10 +37,10 @@ describe('Plugin', () => {
     expect(context.store.registerModule).toHaveBeenCalled()
   })
 
-  it('does not add the store module on client side', async () => {
+  it('adds the store module on client side', async () => {
     await (Plugin(context, () => {}))
 
-    expect(context.store.registerModule).not.toHaveBeenCalled()
+    expect(context.store.registerModule).toHaveBeenCalled()
   })
 })
 
@@ -152,41 +152,37 @@ describe('Helpers', () => {
   })
 
   it('injects login and logout', () => {
-    actions.forEach(a =>
-      expect(inject).toHaveBeenCalledWith(a, expect.any(Function))
-    )
+    actions.forEach(a => expect(inject).toHaveBeenCalledWith(a, expect.any(Function)))
   })
 
-  actions.forEach(actionName =>
-    describe(actionName, () => {
-      let action
+  actions.forEach(actionName => describe(actionName, () => {
+    let action
 
-      beforeEach(() => {
-        action = inject.mock.calls.find(([name]) => name === actionName)[1]
-      })
-
-      it('redirects correctly', () => {
-        action()
-
-        const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(context.route.fullPath)}`
-        expect(global.window.location.assign).toHaveBeenCalledWith(expected)
-      })
-
-      it('redirects correctly with custom redirect url', () => {
-        const redirectUrl = '/custom'
-        action(redirectUrl)
-
-        const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(redirectUrl)}`
-        expect(global.window.location.assign).toHaveBeenCalledWith(expected)
-      })
-
-      it('retains query parameters during redirect', () => {
-        const redirectUrl = '/custom?foo=bar'
-        action(redirectUrl)
-
-        const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(redirectUrl)}`
-        expect(global.window.location.assign).toHaveBeenCalledWith(expected)
-      })
+    beforeEach(() => {
+      action = inject.mock.calls.find(([name]) => name === actionName)[1]
     })
-  )
+
+    it('redirects correctly', () => {
+      action()
+
+      const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(context.route.fullPath)}`
+      expect(global.window.location.assign).toHaveBeenCalledWith(expected)
+    })
+
+    it('redirects correctly with custom redirect url', () => {
+      const redirectUrl = '/custom'
+      action(redirectUrl)
+
+      const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(redirectUrl)}`
+      expect(global.window.location.assign).toHaveBeenCalledWith(expected)
+    })
+
+    it('retains query parameters during redirect', () => {
+      const redirectUrl = '/custom?foo=bar'
+      action(redirectUrl)
+
+      const expected = `/auth/${actionName}?redirect-url=${encodeURIComponent(redirectUrl)}`
+      expect(global.window.location.assign).toHaveBeenCalledWith(expected)
+    })
+  }))
 })


### PR DESCRIPTION
# Token refresh

- Token refresh has been re-worked to handle full (not partial) session replacement
- Refactor `updateToken` toBe `authenticate` since this a better representation of the process
- Add deprecated warning for `updateToken` (in case users had manipulated the handler)
- Separate the refresh token into it's won flow `useRefreshToken`