### PR TITLE
refactor: change client-sessions for cookie-session

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,4 +1,4 @@
-const sessions = require('client-sessions')
+const sessions = require('cookie-session')
 const OAuth2 = require('client-oauth2')
 const { atob, btoa } = require('Base64')
 const { parse } = require('qs')
@@ -51,18 +51,19 @@ Handler.prototype.redirect = function redirect (path) {
   this.res.end()
 }
 
-Handler.prototype.createSession = function createSession () {
-  if (this.req[this.opts.sessionName]) return Promise.resolve()
+Handler.prototype.createSession = function createSession() {
+  if (this.req.session) return Promise.resolve()
   const session = sessions({
-    cookieName: this.opts.sessionName,
+    name: this.opts.sessionName,
     secret: this.opts.secretKey,
-    duration: 24 * 60 * 60 * 1000
+    sameSite: 'lax',
+    maxAge: 24 * 60 * 60 * 1000
   })
   return new Promise(resolve => session(this.req, this.res, resolve))
 }
 
 Handler.prototype.getSessionToken = function getSessionToken () {
-  const { token } = this.req[this.opts.sessionName] || {}
+  const { token } = this.req.session || {}
 
   return token || {}
 }
@@ -105,10 +106,10 @@ Handler.prototype.authenticateCallbackToken = async function authenticateCallbac
 
 Handler.prototype.saveData = async function saveData (token) {
   await this.createSession()
-  if (!token) return this.req[this.opts.sessionName].reset()
+  if (!token) return this.req.session = null
 
   const { accessToken, refreshToken, expires } = token
-  this.req[this.opts.sessionName].token = { accessToken, refreshToken, expires }
+  this.req.session.token = { accessToken, refreshToken, expires }
   this.req.accessToken = accessToken
 
   const fetchUser = async () => {
@@ -119,8 +120,8 @@ Handler.prototype.saveData = async function saveData (token) {
     }
   }
 
-  const user = this.req[this.opts.sessionName].user || await fetchUser()
-  this.req[this.opts.sessionName].user = user
+  const user = this.req.session.user || await fetchUser()
+  this.req.session.user = user
   this.req.user = user
   return true
 }
@@ -196,8 +197,7 @@ Handler.prototype.redirectToOAuth = async function redirectToOAuth (redirect) {
 
 Handler.prototype.logout = async function logout () {
   await this.createSession()
-  this.req[this.opts.sessionName].reset()
-  this.req[this.opts.sessionName].setDuration(0)
+  this.req.session = null
 
   const redirectUrl = parse(this.req.url.split('?')[1])['redirect-url'] || '/'
   try {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "Base64": "^1.0.1",
     "client-oauth2": "^4.1.0",
-    "client-sessions": "^0.8.0",
+    "cookie-session": "^1.4.0",
     "qs": "^6.5.0",
     "url-join": "^4.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,13 +2832,6 @@ client-oauth2@^4.1.0:
     popsicle "12.0.4"
     safe-buffer "^5.1.1"
 
-client-sessions@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/client-sessions/-/client-sessions-0.8.0.tgz#a7d8c5558ad5d56f2a199f3533eb654b5df893fd"
-  integrity sha1-p9jFVYrV1W8qGZ81M+tlS134k/0=
-  dependencies:
-    cookies "^0.7.0"
-
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -3050,6 +3043,15 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-session@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/cookie-session/-/cookie-session-1.4.0.tgz#c325aea685ceb9c8e4fd00b0313a46d547747380"
+  integrity sha512-0hhwD+BUIwMXQraiZP/J7VP2YFzqo6g4WqZlWHtEHQ22t0MeZZrNBSCxC1zcaLAs8ApT3BzAKizx9gW/AP9vNA==
+  dependencies:
+    cookies "0.8.0"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -3065,13 +3067,13 @@ cookie@^0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
-cookies@^0.7.0:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.3.tgz#7912ce21fbf2e8c2da70cf1c3f351aecf59dadfa"
-  integrity sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==
+cookies@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz#1293ce4b391740a8406e3c9870e828c4b54f3f90"
+  integrity sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==
   dependencies:
-    depd "~1.1.2"
-    keygrip "~1.0.3"
+    depd "~2.0.0"
+    keygrip "~1.1.0"
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -3513,6 +3515,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -5965,10 +5972,12 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keygrip@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.3.tgz#399d709f0aed2bab0a059e0cdd3a5023a053e1dc"
-  integrity sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==
+keygrip@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
+  integrity sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
+  dependencies:
+    tsscmp "1.0.6"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -9465,6 +9474,11 @@ tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsscmp@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Fixes #55 

This could be considered a breaking change since session is now accessed through `req.session` rather than `req[cookieName]`. This can probably be fixed with a Proxy but not sure if that's ideal 

This dependency change also goes away from encryption and uses verification instead