### PR TITLE
Remove check for refresh token on auth

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -136,7 +136,7 @@ Handler.prototype.authenticate = async function authenticate () {
 
   const { accessToken, refreshToken } = this.getSessionToken()
 
-  if (!accessToken || !refreshToken) {
+  if (!accessToken) {
     return null
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-oauth",
-  "version": "2.7.0",
+  "version": "2.8.0-beta.1",
   "description": "OAuth module for your Nuxt applications",
   "main": "index.js",
   "repository": "https://github.com/SohoHouse/nuxt-oauth",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-oauth",
-  "version": "2.8.0-beta.1",
+  "version": "2.8.0",
   "description": "OAuth module for your Nuxt applications",
   "main": "index.js",
   "repository": "https://github.com/SohoHouse/nuxt-oauth",

--- a/test/unit/handler.js
+++ b/test/unit/handler.js
@@ -313,6 +313,12 @@ describe('Handler', () => {
       expect(returnedToken).toEqual(mockToken)
     })
 
+    it('returns null without accessToken', async () => {
+      handler.getSessionToken.mockReturnValueOnce({})
+      const result = await handler.authenticate()
+      expect(result).toBeNull()
+    })
+
     it('does nothing else if no token exists already', async () => {
       handler.req[options.sessionName] = {}
       handler.getSessionToken.mockReturnValueOnce({})


### PR DESCRIPTION
Auth currently fails if a token doesn't have a refresh token. 

Removing the check for the refresh token to make sure auth works in that situation