### PR TITLE
Allow cookie options to be set on client-sessions

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -56,7 +56,8 @@ Handler.prototype.createSession = function createSession () {
   const session = sessions({
     cookieName: this.opts.sessionName,
     secret: this.opts.secretKey,
-    duration: 24 * 60 * 60 * 1000
+    duration: 24 * 60 * 60 * 1000,
+    cookie: this.opts.cookie || {}
   })
   return new Promise(resolve => session(this.req, this.res, resolve))
 }

--- a/test/unit/handler.js
+++ b/test/unit/handler.js
@@ -39,6 +39,9 @@ beforeEach(() => {
     accessTokenPath: '/token2',
     sessionName: 'testSession',
     secretKey: 'sekret',
+    cookie: {
+      sameSite: 'lax'
+    },
     fetchUser: jest.fn(() => user),
     onLogout: jest.fn(() => {})
   }
@@ -139,7 +142,8 @@ describe('Handler', () => {
       expect(sessions).toBeCalledWith({
         duration: 86400000, // 1 day,
         cookieName: options.sessionName,
-        secret: options.secretKey
+        secret: options.secretKey,
+        cookie: options.cookie
       })
     })
 


### PR DESCRIPTION
Add `nuxt-oauth` options for `client-sessions` cookie options.

```
['nuxt-oauth', { cookie: { sameSite: 'strict' } }]