### PR TITLE
add option duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ yarn add nuxt-oauth
 modules: ['nuxt-oauth'],
 oauth: {
   sessionName: 'mySession',
+  duration: 24 * 60 * 60 * 1000,
   secretKey: process.env.SECRET_KEY,
   oauthHost: process.env.OAUTH_HOST,
   oauthClientID: process.env.OAUTH_CLIENT_ID,

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -56,7 +56,7 @@ Handler.prototype.createSession = function createSession () {
   const session = sessions({
     cookieName: this.opts.sessionName,
     secret: this.opts.secretKey,
-    duration: 24 * 60 * 60 * 1000
+    duration: this.opts.duration || 24 * 60 * 60 * 1000
   })
   return new Promise(resolve => session(this.req, this.res, resolve))
 }


### PR DESCRIPTION
Add option to allow session duration manipulation.

Default to 24 hours: 24 * 60 * 60 * 1000

usage;

```
oauth: {
    duration: 1000 * 60 * 60 * 24 * 365 * 2, // 2 year session duration
}