### PR TITLE
fix(refresh): Properly pass expires to OAuth Token definition

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -134,14 +134,14 @@ Handler.prototype.updateToken = function updateToken (...args) {
 Handler.prototype.authenticate = async function authenticate () {
   await this.createSession()
 
-  const { accessToken, refreshToken } = this.getSessionToken()
+  const { accessToken, refreshToken, expires } = this.getSessionToken()
 
   if (!accessToken) {
     return null
   }
 
   try {
-    const token = await this.auth.createToken(accessToken, refreshToken, 'bearer')
+    const token = await this.auth.createToken(accessToken, refreshToken, 'bearer', { expires_in: expires })
 
     token.expiresIn(new Date(token.expires))
 

--- a/test/unit/handler.js
+++ b/test/unit/handler.js
@@ -281,7 +281,7 @@ describe('Handler', () => {
     it('saves the token', async () => {
       await handler.updateToken()
       expect(mockToken.refresh).not.toHaveBeenCalled()
-      expect(handler.auth.createToken).toHaveBeenCalledWith(token.accessToken, token.refreshToken, 'bearer')
+      expect(handler.auth.createToken).toHaveBeenCalledWith(token.accessToken, token.refreshToken, 'bearer', { expires_in: token.expires })
       expect(handler.saveData).toHaveBeenCalledWith(mockToken)
     })
 
@@ -339,7 +339,7 @@ describe('Handler', () => {
     it('saves the token', async () => {
       await handler.authenticate()
       expect(mockToken.refresh).not.toHaveBeenCalled()
-      expect(handler.auth.createToken).toHaveBeenCalledWith(token.accessToken, token.refreshToken, 'bearer')
+      expect(handler.auth.createToken).toHaveBeenCalledWith(token.accessToken, token.refreshToken, 'bearer', { expires_in: token.expires })
       expect(handler.saveData).toHaveBeenCalledWith(mockToken)
     })
 


### PR DESCRIPTION
Currently, it seems the expires value is not passed within the OAuth2 created token, which in turn makes it impossible to rely on the `token.expired()` mechanic to handle refreshes.

It is unclear to me if that happen only when reloading the token from the Session or all the time, the case I fixed on my end was from loading an already existing session.