### PR TITLE
JS-1039 p1 401 error on client side navigation fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ module.exports = function NuxtOAuth (moduleOptions) {
     src: resolve(__dirname, 'lib/plugin.js'),
     fileName: 'nuxt-oauth.plugin.js',
     options: {
-      moduleName: options.moduleName
+      moduleName: options.moduleName,
+      sessionName: options.sessionName
     }
   })
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,6 +2,7 @@
 import middleware from '@@/.nuxt/middleware'
 
 const moduleName = '<%= options.moduleName %>'
+const sessionName = '<%= options.sessionName %>'
 
 const initStore = async context => {
   if (!context.store) {
@@ -15,11 +16,15 @@ const initStore = async context => {
       namespaced: true,
       state: {
         accessToken: (context.req && context.req.accessToken),
+        expires: (context.req && context.req[sessionName] && context.req[sessionName].token && context.req[sessionName].token.expires),
         user: (context.req && context.req.user)
       },
       mutations: {
         setAccessToken (state, accessToken) {
           state.accessToken = accessToken
+        },
+        setExpiry (state, expires) {
+          state.expires = expires
         }
       }
     }
@@ -38,14 +43,45 @@ const redirectToOAuth = ({ redirect }, action, redirectUrl = '') => {
   if (process.client) {
     window.location.assign(encodedRedirectUrl)
   } else {
-    console.log('redirect(302, encodedRedirectUrl)', encodedRedirectUrl)
     redirect(302, encodedRedirectUrl)
   }
 }
 
-middleware.auth = context => {
+middleware.auth = async context => {
+ 
   const isAuthenticated = checkAuthenticatedRoute(context)
-  const { accessToken = null } = context.store.state[moduleName]
+  const { accessToken = null, expires } = context.store.state[moduleName]
+
+  if(expires) {
+    let expires_in = Math.floor((Date.parse(expires) - Date.now()) / 1000, 1000)
+    if(expires_in < 0) {
+
+      try {
+        // get new token from auth endpoint
+        const {
+          data: { accessToken, refreshToken, expires },
+        } = await context.$axios.get('/auth/refresh', {
+          baseURL: '',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+
+        // set new token within the store
+        context.store.commit('oauth/setAccessToken', accessToken)
+        context.store.commit('oauth/setExpiry', expires)
+        context.$axios.setToken(context.store.state.oauth.accessToken, 'Bearer')
+        // retry the original request with a new token
+      } catch (error) {
+        // token refresh has failed, the user should be signed out
+        // app.$logout()
+        // redirectToOAuth(context, 'logout', context.route.fullPath)
+      }
+    } else {
+      console.log('nuxt plugin axios - not exipred', expires_in, accessToken);
+    }
+  }
+
 
   if (!isAuthenticated || !!accessToken) return
   redirectToOAuth(context, 'login', context.route.fullPath)


### PR DESCRIPTION
Client side navigation when a token is expired causes 401 page

Steps to reproduce:

1. login & be on homepage
2. wait for the token to expire
3. visit private page once the token expires
4. we should see a 401 page